### PR TITLE
Allow meta in addons.ini file

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1204,10 +1204,14 @@ class TVGuide(xbmcgui.WindowXML):
         wasPlaying = self.player.isPlaying()
         url = self.database.getStreamUrl(channel)
         if url:
-            if str.startswith(url,"plugin://plugin.video.meta") and program is not None:
+            if str.startswith(url,"plugin://plugin.video.meta/movies/play_by_name") and program is not None:
                 import urllib
                 title = urllib.quote(program.title)
                 url += "/%s/%s" % (title, program.language)
+            if str.startswith(url,"plugin://plugin.video.meta/tv/play_by_name") and program is not None:
+                import urllib
+                title = urllib.quote(program.title)
+                url += "%s/%s/%s/%s" % (title, program.season, program.episode, program.language)
             if url[0:9] == 'plugin://':
                 if self.alternativePlayback:
                     xbmc.executebuiltin('XBMC.RunPlugin(%s)' % url)


### PR DESCRIPTION
This minor change will allow a user to add the following two url's for channels in their addons.ini file:

plugin://plugin.video.meta/tv/play_by_name/
plugin://plugin.video.meta/movies/play_by_name/

Allowing so means that a user could, theoretically, add a channel such as Syfy or a movie channel, and when clicking on an episode, the 'channel stream' will automatically pick it up in Meta (so long as the user is using the correct season/episode data format in their xmltv files).

A flaw is that it will only play one episode, then return to the guide, and you'd have to click on the following episode, meaning the user would lose that 'binge watching a channel' experience. We can look into ways of automatically queuing up the following episodes/movies in a playlist later, should you like this change.

Thanks,
Ray.
