### PR TITLE
Better auto-swicth channel with ID input

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -533,11 +533,15 @@ class TVGuide(xbmcgui.WindowXML):
                         self.channelIdx = int(self.channel_number) - 1
                     self.channel_number = ""
                     self.getControl(9999).setLabel(self.channel_number)
-                    self._hideOsdOnly()
-                    self._hideQuickEpg()
-                    self.onRedrawEPG(self.channelIdx, self.viewStartDate)
-                    if ADDON.getSetting('channel.shortcut.auto') == 'true':
-                        xbmc.executebuiltin('Action(Select)')
+                    if xbmc.getCondVisibility('Player.HasMedia+Control.IsVisible(5000)'):
+                        self._hideOsdOnly()
+                        self._hideQuickEpg()
+                        self.onRedrawEPG(self.channelIdx, self.viewStartDate)
+                        if ADDON.getSetting('channel.shortcut.auto') == 'true': xbmc.executebuiltin('Action(Select)')
+                    else:
+                        self._hideOsdOnly()
+                        self._hideQuickEpg()
+                        self.onRedrawEPG(self.channelIdx, self.viewStartDate)
             return
 
         if action.getId() in COMMAND_ACTIONS["NOW_LISTING"]:


### PR DESCRIPTION
This is a better way to change channels on ID input. If you have a fullscreen video playing, it will automatically play the channel you input. However, if you are in the EPG it will not automatically play, instead just highlighting the channel. This assumes that the end user switching when in fullscreen video definitely wants to switch, where as in the EPG screen is still just browsing and a switch isn't totally necessary.