### PR TITLE
new osd big view

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -795,6 +795,7 @@ class TVGuide(xbmcgui.WindowXML):
 
         elif action.getId() in COMMAND_ACTIONS["CHANNEL_LISTING"]:
             self.showListing(self.osdChannel)
+
     def onActionLastPlayedMode(self, action):
         if action.getId() == ACTION_MOUSE_MOVE:
             if ADDON.getSetting('mouse.controls') == "true":

--- a/gui.py
+++ b/gui.py
@@ -236,7 +236,7 @@ class TVGuide(xbmcgui.WindowXML):
     C_MAIN_OSD = 6000
     C_MAIN_OSD_BIG = 66000
     C_MAIN_OSD_BIG_CHANNEL_LOGO = 66004
-    C_MAIN_OSD_BIG_CHANNEL_IMAGE = 6006
+    C_MAIN_OSD_BIG_CHANNEL_IMAGE = 66006
     C_MAIN_OSD_BIG_PROGRESS = 66011
     C_MAIN_OSD_TITLE = 6001
     C_MAIN_OSD_TIME = 6002
@@ -629,7 +629,6 @@ class TVGuide(xbmcgui.WindowXML):
             self.onActionTVMode(action)
         elif self.mode == MODE_OSD:
             self.onActionOSDMode(action)
-            self.onActionOSDMode(action)
         elif self.mode == MODE_OSD_BIG:
             self.onActionOSDBigMode(action)
         elif self.mode == MODE_EPG:
@@ -691,6 +690,7 @@ class TVGuide(xbmcgui.WindowXML):
         elif action.getId() in COMMAND_ACTIONS["CLOSE"]:
             self._hideOsd()
             self._hideOsdBig()
+
         elif action.getId() in COMMAND_ACTIONS["PLAY"]:
             self._hideOsd()
             self.playOrChoose(self.osdProgram)
@@ -2868,6 +2868,7 @@ class TVGuide(xbmcgui.WindowXML):
     def _hideOsdBig(self):
         self.mode = MODE_TV
         self._hideControl(self.C_MAIN_OSD_BIG)
+
     def _hideLastPlayed(self):
         self.mode = MODE_TV
         self._hideControl(self.C_MAIN_LAST_PLAYED)

--- a/gui.py
+++ b/gui.py
@@ -58,6 +58,7 @@ MODE_EPG = 'EPG'
 MODE_QUICK_EPG = 'QUICKEPG'
 MODE_TV = 'TV'
 MODE_OSD = 'OSD'
+MODE_OSD_BIG = 'OSD_BIG'
 MODE_LASTCHANNEL = 'LASTCHANNEL'
 
 COMMAND_ACTIONS = ActionEditor.getCommandActions()
@@ -212,6 +213,7 @@ class TVGuide(xbmcgui.WindowXML):
     C_MAIN_MOUSE_MINE1 = 4317
     C_MAIN_MOUSE_NEXT_DAY = 4318
     C_MAIN_MOUSE_PREV_DAY = 4319
+    C_MAIN_MOUSE_OSD_BIG = 4320
     C_MAIN_BACKGROUND = 4600
     C_MAIN_HEADER = 4601
     C_MAIN_FOOTER = 4602
@@ -232,6 +234,10 @@ class TVGuide(xbmcgui.WindowXML):
     C_QUICK_EPG_HEADER = 14601
     C_QUICK_EPG_FOOTER = 14602
     C_MAIN_OSD = 6000
+    C_MAIN_OSD_BIG = 66000
+    C_MAIN_OSD_BIG_CHANNEL_LOGO = 66004
+    C_MAIN_OSD_BIG_CHANNEL_IMAGE = 6006
+    C_MAIN_OSD_BIG_PROGRESS = 66011
     C_MAIN_OSD_TITLE = 6001
     C_MAIN_OSD_TIME = 6002
     C_MAIN_OSD_DESCRIPTION = 6003
@@ -348,7 +354,10 @@ class TVGuide(xbmcgui.WindowXML):
         self.action_index = 0
 
         self.osdEnabled = False
+        self.osdBigEnabled = False
         self.osdEnabled = ADDON.getSetting('enable.osd') == 'true' and ADDON.getSetting(
+            'alternative.playback') != 'true'
+        self.osdBigEnabled = ADDON.getSetting('enable.osd') == 'true' and ADDON.getSetting(
             'alternative.playback') != 'true'
         self.upNextEnabled = False
         self.upNextEnabled = ADDON.getSetting('enable.nextup') == 'true'
@@ -445,6 +454,7 @@ class TVGuide(xbmcgui.WindowXML):
         self._hideControl(self.C_QUICK_EPG_MOUSE_CONTROLS)
         self._hideControl(self.C_MAIN_LAST_PLAYED_MOUSE_CONTROLS)
         self._hideControl(self.C_MAIN_MOUSE_CONTROLS, self.C_MAIN_OSD)
+        self._hideControl(self.C_MAIN_MOUSE_CONTROLS, self.C_MAIN_OSD_BIG)
         self._hideControl(self.C_MAIN_LAST_PLAYED)
         self._hideControl(self.C_UP_NEXT)
         self._hideControl(self.C_QUICK_EPG)
@@ -537,6 +547,7 @@ class TVGuide(xbmcgui.WindowXML):
         if action.getId() in COMMAND_ACTIONS["STOP"]:
             self.tryingToPlay = False
             self._hideOsdOnly()
+            self._hideOsdBigOnly()
             self._hideQuickEpg()
 
             self.currentChannel = None
@@ -618,6 +629,9 @@ class TVGuide(xbmcgui.WindowXML):
             self.onActionTVMode(action)
         elif self.mode == MODE_OSD:
             self.onActionOSDMode(action)
+            self.onActionOSDMode(action)
+        elif self.mode == MODE_OSD_BIG:
+            self.onActionOSDBigMode(action)
         elif self.mode == MODE_EPG:
             self.onActionEPGMode(action)
         elif self.mode == MODE_QUICK_EPG:
@@ -641,10 +655,10 @@ class TVGuide(xbmcgui.WindowXML):
             self.onRedrawEPG(self.channelIdx, self.viewStartDate)
 
         elif action.getId() in COMMAND_ACTIONS["MENU"]:
-            self.currentProgram = self.database.getCurrentProgram(self.currentChannel)
-            if self.currentProgram is not None:
-                self._showContextMenu(self.currentProgram)
-        elif action.getId() in COMMAND_ACTIONS["OSD"]:
+            self.osdChannel = self.currentChannel
+            self.osdProgram = self.database.getCurrentProgram(self.osdChannel)
+            self._showOsdBig()
+        elif action.getId() in COMMAND_ACTIONS["OSD"] + COMMAND_ACTIONS["PLAY"]:
             self.osdChannel = self.currentChannel
             self.osdProgram = self.database.getCurrentProgram(self.osdChannel)
             self._showOsd()
@@ -676,19 +690,15 @@ class TVGuide(xbmcgui.WindowXML):
 
         elif action.getId() in COMMAND_ACTIONS["CLOSE"]:
             self._hideOsd()
-            self.viewStartDate = datetime.datetime.today()
-            self.viewStartDate -= datetime.timedelta(minutes=self.viewStartDate.minute % 60, seconds=self.viewStartDate.second)
-            self.currentProgram = self.database.getCurrentProgram(self.currentChannel)
-            self.onRedrawEPG(self.channelIdx, self.viewStartDate)
-
+            self._hideOsdBig()
         elif action.getId() in COMMAND_ACTIONS["PLAY"]:
             self._hideOsd()
             self.playOrChoose(self.osdProgram)
 
         elif action.getId() in COMMAND_ACTIONS["MENU"]:
+            self.osdChannel = self.currentChannel
             self.osdProgram = self.database.getCurrentProgram(self.osdChannel)
-            if self.osdProgram is not None:
-                self._showContextMenu(self.osdProgram)
+            self._showOsdBig()
 
         elif action.getId() in COMMAND_ACTIONS["PLAY_NEXT_CHANNEL"]:
             self._channelUp()
@@ -727,7 +737,64 @@ class TVGuide(xbmcgui.WindowXML):
         elif action.getId() in COMMAND_ACTIONS["CHANNEL_LISTING"]:
             self.showListing(self.osdChannel)
 
+    def onActionOSDBigMode(self, action):
+        if action.getId() == ACTION_MOUSE_MOVE:
+            if ADDON.getSetting('mouse.controls') == "true":
+                self._showControl(self.C_MAIN_OSD_MOUSE_CONTROLS)
+            return
 
+        if action.getId() in COMMAND_ACTIONS["OSD"]:
+            self._hideOsdBig()
+
+        elif action.getId() in COMMAND_ACTIONS["CLOSE"]:
+            self._hideOsdBig()
+            self._hideOsd()
+
+        elif action.getId() in COMMAND_ACTIONS["PLAY"]:
+            self._hideOsdBig()
+            self.playOrChoose(self.osdProgram)   
+
+        elif action.getId() in COMMAND_ACTIONS["MENU"]:
+            self.osdProgram = self.database.getCurrentProgram(self.osdChannel)
+            if self.osdProgram is not None:
+                self._showContextMenu(self.osdProgram)
+
+        elif action.getId() in COMMAND_ACTIONS["PLAY_NEXT_CHANNEL"]:
+            self._channelUp()
+            self._hideOsdBig()
+
+        elif action.getId() in COMMAND_ACTIONS["PLAY_PREV_CHANNEL"]:
+            self._channelDown()
+            self._hideOsdBig()
+
+        elif action.getId() in COMMAND_ACTIONS["UP"]:
+            self.osdChannel = self.database.getPreviousChannel(self.osdChannel)
+            self.osdProgram = self.database.getCurrentProgram(self.osdChannel)
+            self._showOsdBig()
+            self.osdActive = True
+
+        elif action.getId() in COMMAND_ACTIONS["DOWN"]:
+            self.osdChannel = self.database.getNextChannel(self.osdChannel)
+            self.osdProgram = self.database.getCurrentProgram(self.osdChannel)
+            self._showOsdBig()
+            self.osdActive = True
+
+        elif action.getId() in COMMAND_ACTIONS["LEFT"]:
+            previousProgram = self.database.getPreviousProgram(self.osdProgram)
+            if previousProgram:
+                self.osdProgram = previousProgram
+                self._showOsdBig()
+            self.osdActive = True
+
+        elif action.getId() in COMMAND_ACTIONS["RIGHT"]:
+            nextProgram = self.database.getNextProgram(self.osdProgram)
+            if nextProgram:
+                self.osdProgram = nextProgram
+                self._showOsdBig()
+            self.osdActive = True
+
+        elif action.getId() in COMMAND_ACTIONS["CHANNEL_LISTING"]:
+            self.showListing(self.osdChannel)
     def onActionLastPlayedMode(self, action):
         if action.getId() == ACTION_MOUSE_MOVE:
             if ADDON.getSetting('mouse.controls') == "true":
@@ -1187,6 +1254,7 @@ class TVGuide(xbmcgui.WindowXML):
             self.player.stop()
             self.tryingToPlay = False
             self._hideOsdOnly()
+            self._hideOsdBigOnly()
             self._hideQuickEpg()
 
             self.currentChannel = None
@@ -1257,6 +1325,9 @@ class TVGuide(xbmcgui.WindowXML):
         elif controlId == self.C_MAIN_MOUSE_SEARCH:
             self.programSearchSelect()
             return
+        elif controlId == self.C_MAIN_MOUSE_OSD_BIG:
+            self._showOsdBig()
+            self._hideOsdOnly()
         elif controlId == self.C_MAIN_PROGRAM_CATEGORIES:
             self.categorySearch()
             return
@@ -2672,6 +2743,60 @@ class TVGuide(xbmcgui.WindowXML):
         self.mode = MODE_OSD
         self._showControl(self.C_MAIN_OSD)
 
+    def _showOsdBig(self):
+        if not self.osdEnabled:
+            return
+
+        if self.mode != MODE_OSD_BIG:
+            self.osdChannel = self.currentChannel
+
+        if not self.osdChannel:
+            self.osdChannel = self.currentChannel
+        if not self.osdChannel:
+            return #TODO this should not happen
+        if self.osdProgram is not None:
+            self.setControlLabel(self.C_MAIN_OSD_TITLE, '[B]%s[/B]' % self.osdProgram.title)
+            if self.osdProgram.startDate or self.osdProgram.endDate:
+                self.setControlLabel(self.C_MAIN_OSD_TIME, '[B]%s - %s[/B]' % (
+                    self.formatTime(self.osdProgram.startDate), self.formatTime(self.osdProgram.endDate)))
+            else:
+                self.setControlLabel(self.C_MAIN_OSD_TIME, '')
+            if self.osdProgram.startDate and self.osdProgram.endDate:
+                osdprogramprogresscontrol = self.getControl(self.C_MAIN_OSD_BIG_PROGRESS)
+                if osdprogramprogresscontrol:
+                    osdprogramprogresscontrol.setPercent(self.percent(self.osdProgram.startDate,self.osdProgram.endDate))
+            self.setControlText(self.C_MAIN_OSD_DESCRIPTION, self.osdProgram.description)
+            self.setControlLabel(self.C_MAIN_OSD_CHANNEL_TITLE, self.osdChannel.title)
+            if self.osdProgram.channel.logo is not None:
+                self.setControlImage(self.C_MAIN_OSD_BIG_CHANNEL_LOGO, self.osdProgram.channel.logo)
+            else:
+                self.setControlImage(self.C_MAIN_OSD_BIG_CHANNEL_LOGO, '')
+            if self.osdProgram.imageSmall is not None:
+                self.setControlImage(self.C_MAIN_OSD_BIG_CHANNEL_IMAGE, self.osdProgram.imageSmall)
+            else:
+                self.setControlImage(self.C_MAIN_OSD_BIG_CHANNEL_IMAGE, '')
+
+            nextOsdProgram = self.database.getNextProgram(self.osdProgram)
+            if nextOsdProgram:
+                self.setControlText(self.C_NEXT_OSD_DESCRIPTION, nextOsdProgram.description)
+                self.setControlLabel(self.C_NEXT_OSD_TITLE, nextOsdProgram.title)
+                if nextOsdProgram.startDate or nextOsdProgram.endDate:
+                    self.setControlLabel(self.C_NEXT_OSD_TIME, '%s - %s' % (
+                        self.formatTime(nextOsdProgram.startDate), self.formatTime(nextOsdProgram.endDate)))
+                else:
+                    self.setControlLabel(self.C_NEXT_OSD_TIME, '')
+                try:
+                    nextOsdControl = self.getControl(self.C_NEXT_OSD_CHANNEL_IMAGE)
+                    if nextOsdControl != None and nextOsdProgram.imageSmall is not None:
+                        nextOsdControl.setImage(nextOsdProgram.imageSmall)
+                    elif nextOsdControl != None:
+                        nextOsdControl.setImage('')
+                except:
+                    pass
+
+        self.mode = MODE_OSD_BIG
+        self._showControl(self.C_MAIN_OSD_BIG)
+
     def _showLastPlayedChannel(self):
         if not self.lastChannel:
             return
@@ -2737,6 +2862,12 @@ class TVGuide(xbmcgui.WindowXML):
         self.mode = MODE_TV
         self._hideControl(self.C_MAIN_OSD)
 
+    def _hideOsdBigOnly(self):
+        self._hideControl(self.C_MAIN_OSD_BIG)
+
+    def _hideOsdBig(self):
+        self.mode = MODE_TV
+        self._hideControl(self.C_MAIN_OSD_BIG)
     def _hideLastPlayed(self):
         self.mode = MODE_TV
         self._hideControl(self.C_MAIN_LAST_PLAYED)

--- a/resources/skins/Default/720p/script-tvguide-main.xml
+++ b/resources/skins/Default/720p/script-tvguide-main.xml
@@ -1929,7 +1929,7 @@
             <posy>500</posy>
             <width>1280</width>
             <height>220</height>
-            <visible>!Control.IsVisible(6000)</visible>
+            <visible>![Control.IsVisible(6000)]+Control.IsVisible(5000)+Control.IsVisible(66000)</visible>
             <animation effect="fade" start="0" end="100" time="0">VisibleChange</animation>
 
             <control type="image">
@@ -2238,6 +2238,336 @@
                     <description>time label</description>
                     <posx>10r</posx>
                     <top>-495</top>
+                    <width>200</width>
+                    <height>30</height>
+                    <align>right</align>
+                    <aligny>center</aligny>
+                    <font>font28_title</font>
+                    <textcolor>white</textcolor>
+                    <shadowcolor>black</shadowcolor>
+                    <label>$INFO[System.Time]</label>
+                    <animation effect="slide" start="0,0" end="-40,0" time="75" condition="Window.IsVisible(Mutebug)">conditional</animation>
+                </control>
+
+        </control>
+
+        <control type="label" id="66000">
+            <description>visibility marker for OSD Big Info Window</description>
+        </control>
+        <control type="group">
+            <description>OSD Big Info Window</description>
+            <posx>0</posx>
+            <posy>0</posy>
+            <width>1280</width>
+            <height>720</height>
+            <visible>![Control.IsVisible(66000)]+Control.IsVisible(5000)</visible>
+            <animation effect="fade" start="0" end="100" time="0">VisibleChange</animation>
+
+            <control type="image">
+                <description>header</description>
+                <posx>0</posx>
+                <posy>0</posy>
+                <width>1280</width>
+                <height>50</height>
+                <texture>black-back.png</texture>
+                <visible>true</visible>
+            </control>
+
+            <control type="image">
+                <description>footer</description>
+                <posx>0</posx>
+                <posy>50</posy>
+                <width>1280</width>
+                <height>670</height>
+                <texture>black-back.png</texture>
+                <visible>true</visible>
+            </control>
+
+            <control type="button" id="6012">
+                <description>play</description>
+                <posx>0</posx>
+                <posy>0</posy>
+                <width>1280</width>
+                <height>680</height>
+                <label></label>
+                <font>font13</font>
+                <aligny>center</aligny>
+                <align>center</align>
+                <textcolor>grey</textcolor>
+                <focusedcolor>black</focusedcolor>
+                <texturefocus></texturefocus>
+                <texturenofocus></texturenofocus>
+            </control>
+
+<!-- OSD Mouse controls Vertical-->
+            <control type="label" id="6300">
+                <description>visibility marker for mouse control group</description>
+                <posx>0</posx>
+                <posy>0</posy>
+                <width>40</width>
+                <height>40</height>
+            </control>
+            <control type="group">
+                <visible>true</visible>
+                <posx>0</posx>
+                <posy>0</posy>
+                <width>1280</width>
+                <height>720</height>
+                <visible>!Control.IsVisible(6300)</visible>
+
+                  <control type="button">
+                    <description>Right</description>
+                    <posx>1250</posx>
+                    <posy>0</posy>
+                    <width>28</width>
+                    <height>28</height>
+                    <textcolor>ffffffff</textcolor>
+                    <font>font13</font>
+                    <label></label>
+                    <texturefocus>osd_right.png</texturefocus>
+                    <texturenofocus>osd_right.png</texturenofocus>
+                    <onclick>Right</onclick>
+                </control>
+
+                <control type="button">
+                    <description>Left</description>
+                    <posx>1210</posx>
+                    <posy>0</posy>
+                    <width>28</width>
+                    <height>28</height>
+                    <textcolor>ffffffff</textcolor>
+                    <font>font13</font>
+                    <label></label>
+                    <texturefocus>osd_left.png</texturefocus>
+                    <texturenofocus>osd_left.png</texturenofocus>
+                    <onclick>Left</onclick>
+                </control>
+
+                 <control type="button">
+                    <description>Up</description>
+                    <posx>1250</posx>
+                    <posy>70</posy>
+                    <width>28</width>
+                    <height>28</height>
+                    <textcolor>ffffffff</textcolor>
+                    <font>font13</font>
+                    <label></label>
+                    <texturefocus>osd_up.png</texturefocus>
+                    <texturenofocus>osd_up.png</texturenofocus>
+                    <onclick>Up</onclick>
+                </control>
+
+                <control type="button">
+                    <description>Down</description>
+                    <posx>1250</posx>
+                    <posy>105</posy>
+                    <width>28</width>
+                    <height>28</height>
+                    <textcolor>ffffffff</textcolor>
+                    <font>font13</font>
+                    <label></label>
+                    <texturefocus>osd_down.png</texturefocus>
+                    <texturenofocus>osd_down.png</texturenofocus>
+                    <onclick>Down</onclick>
+                </control>
+
+                <control type="button">
+                    <description>OK</description>
+                    <posx>1250</posx>
+                    <posy>140</posy>
+                    <width>28</width>
+                    <height>28</height>
+                    <textcolor>ffffffff</textcolor>
+                    <font>font13</font>
+                    <texturefocus>button_refresh.png</texturefocus>
+                    <texturenofocus>button_refresh.png</texturenofocus>
+                    <onclick>info</onclick>
+                    <onclick>down</onclick>
+                </control>
+
+                <control type="button">
+                    <description>Back to Main EPGHome Screen</description>
+                    <posx>1250</posx>
+                    <posy>180</posy>
+                    <width>28</width>
+                    <height>28</height>
+                    <textcolor>ffffffff</textcolor>
+                    <font>font13</font>
+                    <label></label>
+                    <texturefocus>back.png</texturefocus>
+                    <texturenofocus>back.png</texturenofocus>
+                    <onclick>Back</onclick>
+                </control>
+
+                <control type="button">
+                    <description>OSD Mouse controls Now All Channels</description>
+                    <posx>1150</posx>
+                    <posy>180</posy>
+                    <width>60</width>
+                    <height>28</height>
+                    <textcolor>grey</textcolor>
+                    <font>font10</font>
+                    <label>NOW</label>
+                    <texturefocus>-</texturefocus>
+                    <texturenofocus>-</texturenofocus>
+                    <onclick>info</onclick>
+                    <onclick>up</onclick>
+                </control>
+                <control type="button">
+                    <description>OSD Mouse controls Last Channel Info</description>
+                    <posx>1200</posx>
+                    <posy>180</posy>
+                    <width>50</width>
+                    <height>28</height>
+                    <textcolor>grey</textcolor>
+                    <font>font10</font>
+                    <label>LAST</label>
+                    <texturefocus>-</texturefocus>
+                    <texturenofocus>-</texturenofocus>
+                    <onclick>info</onclick>
+                    <onclick>left</onclick>
+                </control>
+            </control>
+
+            <!-- Program description -->
+            <control type="label" id="6001">
+                <description>Program title</description>
+                <posx>30</posx>
+                <posy>110</posy>
+                <width>594</width>
+                <height>30</height>
+                <label>[B]Title[/B]</label>
+                <textcolor>ffffffff</textcolor>
+                <font>font15</font>
+            </control>
+
+            <control type="label" id="6002">
+                <description>Program time</description>
+                <posx>386r</posx>
+                <posy>110</posy>
+                <width>130</width>
+                <height>30</height>
+                <label>[B]18:00 - 20:00[/B]</label>
+                <textcolor>ffffffff</textcolor>
+                <font>font15</font>
+                <align>right</align>
+
+            </control>
+            <control type="image" id="66004">
+                <description>Program channel logo</description>
+                <posx>5</posx>
+                <posy>5</posy>
+                <width>160</width>
+                <height>40</height>
+                <aspectratio>keep</aspectratio>
+                <colordiffuse>white</colordiffuse>
+            </control>
+            <control type="progress" id="66011">
+                <posx>764</posx>
+                <posy>140</posy>
+                <width>130</width>
+                <height>5</height>
+                <lefttexture></lefttexture>
+                <righttexture></righttexture>
+                <texturebg colordiffuse="white">tvg-button-nofocus.png</texturebg>
+                <midtexture colordiffuse="grey">tvg-button-focus.png</midtexture>
+                <visible>IntegerGreaterThan(Control.GetLabel(66011),0)</visible>
+            </control>
+            <control type="textbox" id="6003">
+                <description>Program description</description>
+                <posx>30</posx>
+                <posy>160</posy>
+                <width>864</width>
+                <height>421</height>
+                <label>Description</label>
+                <textcolor>ffffffff</textcolor>
+                <font>font14</font>
+                <wrapmultiline>true</wrapmultiline>
+                <autoscroll time="3600" delay="6000" repeat="6000">true</autoscroll>
+            </control>
+
+            <control type="label" id="6005">
+                <description>Program channel text</description>
+                <posx>30</posx>
+                <posy>70</posy>
+                <width>894</width>
+                <height>30</height>
+                <textcolor>grey</textcolor>
+                <font>font14_title</font>
+                <align></align>
+                <!--<visible>StringCompare(Control.GetLabel(6004),)</visible>-->
+                <visible>true</visible>
+            </control>
+
+            <control type="image" id="66006">
+                <description>Program image</description>
+                <posx>924</posx>
+                <posy>110</posy>
+                <width>296</width>
+                <height>177</height>
+                <aspectratio>keep</aspectratio>
+                <texture>tvg-tv.png</texture>
+                <visible>true</visible>
+            </control>
+
+            <control type="textbox" id="6007">
+                <description>Next Program description</description>
+                <posx>30</posx>
+                <posy>494</posy>
+                <width>864</width>
+                <height>124</height>
+                <label>Description</label>
+                <textcolor>ffcccccc</textcolor>
+                <font>font14</font>
+                <wrapmultiline>true</wrapmultiline>
+                <autoscroll time="3600" delay="6000" repeat="6000">true</autoscroll>
+                <visible>false</visible>
+            </control>
+
+            <control type="label" id="6008">
+                <description>Next Program title</description>
+                <posx>30</posx>
+                <posy>604</posy>
+                <width>594</width>
+                <height>30</height>
+                <label>[B]Title[/B]</label>
+                <textcolor>ffcccccc</textcolor>
+                <font>font15_title</font>
+                <aligny>center</aligny>
+                <visible>true</visible>
+            </control>
+
+            <control type="label" id="6009">
+                <description>Next Program time</description>
+                <posx>386r</posx>
+                <posy>604</posy>
+                <width>240</width>
+                <height>30</height>
+                <label>[B]18:00 - 20:00[/B]</label>
+                <textcolor>ddcccccc</textcolor>
+                <font>font15</font>
+                <align>right</align>
+                <aligny>top</aligny>
+                <visible>true</visible>
+            </control>
+
+            <control type="image" id="6010">
+                <description>Next Program image</description>
+                <posx>1045</posx>
+                <posy>50</posy>
+                <width>220</width>
+                <height>124</height>
+                <aspectratio>keep</aspectratio>
+                <texture>-</texture>
+                <visible>false</visible>
+            </control>
+
+
+
+                <control type="label">
+                    <description>time label</description>
+                    <posx>10r</posx>
+                    <top>5</top>
                     <width>200</width>
                     <height>30</height>
                     <align>right</align>


### PR DESCRIPTION
a additional osd window to show the osd infos bigger. :D  Same functionality as the osd info bar + skinners can add some more infos, eg. a program image, video & audio codec flags, categories, actors, country, larger fonts & channel logos...

Further i changed some actions in the gui too, to make the new view properly usable. New & changed controls are:

TV / Video Mode
 - "Play" open and toggles the osd info bar now
 - "Menu" opens the Osd Big View

Osd Info Bar
- "Close" just closes the bar without returning to the epg immediately. Press "Close" to return their again.
- "Menu" opens the Osd Big View now

Osd Big View:
- "Close" closes the Osd Big View, returns to TV Mode.
- "Menu" opens the Context Menu


Would be really cool if you merge this. Just download my repo, pick the two changed files, copy it your installation and test it before. I prepared a big view for your default skin too. Just the mouse controls needs to be adjusted maybe.
The changed controls i tested with my remote again & again, works very well.

regards