### PR TITLE
Master

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -332,9 +332,9 @@ class TVGuide(xbmcgui.WindowXML):
         self.vpndefault = False
         try:
             self.api = VPNAPI()
-            if ADDON.getSetting('vpnmgr.connect') == "true"
+            if ADDON.getSetting('vpnmgr.connect') == "true":
                 self.vpnswitch = True
-            if ADDON.getSetting('vpnmgr.default') == "true"
+            if ADDON.getSetting('vpnmgr.default') == "true":
                 self.vpndefault = True
         except:
             self.api = None

--- a/gui.py
+++ b/gui.py
@@ -48,6 +48,7 @@ from strings import *
 from rpc import RPC
 import utils
 import ActionEditor
+from vpnapi import VPNAPI
 
 import streaming
 
@@ -305,7 +306,7 @@ class TVGuide(xbmcgui.WindowXML):
         self.quickEpgView = EPGView()
         self.quickChannelIdx = 0
         self.quickFocusPoint = Point()
-
+            
         self.player = xbmc.Player()
         self.database = None
         self.tvdb_urls = {}
@@ -326,7 +327,18 @@ class TVGuide(xbmcgui.WindowXML):
         self.focusedProgram = None
         self.quickEpgShowInfo = False
         self.playing_catchup_channel = False
-
+        
+        self.vpnswitch = False
+        self.vpndefault = False
+        try:
+            self.api = VPNAPI()
+            if ADDON.getSetting('vpnmgr.connect') == "true"
+                self.vpnswitch = True
+            if ADDON.getSetting('vpnmgr.default') == "true"
+                self.vpndefault = True
+        except:
+            self.api = None
+            
         f = xbmcvfs.File('special://profile/addon_data/script.tvguide.fullscreen/categories.ini','rb')
         lines = f.read().splitlines()
         f.close()
@@ -2553,15 +2565,18 @@ class TVGuide(xbmcgui.WindowXML):
                     title = urllib.quote(program.title)
                     url += "%s/%s/%s/%s" % (title, program.season, program.episode, program.language)
                 if url.startswith('@'):
+                    if self.vpnswitch: self.api.filterAndSwitch(url[1:], 0, self.vpndefault, True)
                     xbmc.executebuiltin('XBMC.RunPlugin(%s)' % url[1:])
                 elif url[0:14] == "ActivateWindow":
                     xbmc.executebuiltin(url)
                 elif url[0:9] == 'plugin://':
+                    if self.vpnswitch: self.api.filterAndSwitch(url, 0, self.vpndefault, True)
                     if self.alternativePlayback:
                         xbmc.executebuiltin('XBMC.RunPlugin(%s)' % url)
                     else:
                         self.player.play(item=url, windowed=self.osdEnabled)
                 else:
+                    if self.vpndefault: self.api.defaultVPN(True)
                     self.player.play(item=url, windowed=self.osdEnabled)
 
             self.tryingToPlay = True
@@ -2642,15 +2657,18 @@ class TVGuide(xbmcgui.WindowXML):
                 url = self.alt_urls.pop(0)
                 #TODO meta
                 if url.startswith('@'):
+                    if self.vpnswitch: self.api.filterAndSwitch(url[1:], 0, self.vpndefault, True)
                     xbmc.executebuiltin('XBMC.RunPlugin(%s)' % url[1:])
                 elif url[0:14] == "ActivateWindow":
                     xbmc.executebuiltin(url)
                 elif url[0:9] == 'plugin://':
+                    if self.vpnswitch: self.api.filterAndSwitch(url, 0, self.vpndefault, True)
                     if self.alternativePlayback:
                         xbmc.executebuiltin('XBMC.RunPlugin(%s)' % url)
                     else:
                         self.player.play(item=url, windowed=self.osdEnabled)
                 else:
+                    if self.vpndefault: self.api.defaultVPN(True)
                     self.player.play(item=url, windowed=self.osdEnabled)
                 self.tryingToPlay = True
                 if ADDON.getSetting('play.minimized') == 'false':

--- a/gui.py
+++ b/gui.py
@@ -2615,6 +2615,10 @@ class TVGuide(xbmcgui.WindowXML):
                 xbmc.executebuiltin('RunScript(%s,%s,%s)' % (script,channel.id,timestamp))
             core = ADDON.getSetting('autoplaywiths.player')
             if core:
+                if url[0:9] == 'plugin://':
+                    if self.vpnswitch: self.api.filterAndSwitch(url, 0, self.vpndefault, True)
+                else:
+                    if self.vpndefault: self.api.defaultVPN(True)
                 xbmc.executebuiltin('PlayWith(%s)' % core)
                 xbmc.executebuiltin('PlayMedia(%s)' % url)
 

--- a/play.py
+++ b/play.py
@@ -1,6 +1,7 @@
 import sys
 import xbmc,xbmcaddon
 import sqlite3
+from vpnapi import VPNAPI
 
 ADDON = xbmcaddon.Addon(id='script.tvguide.fullscreen')
 
@@ -20,4 +21,13 @@ if row:
     url = row[0]
     ADDON.setSetting('playing.channel',channel)
     ADDON.setSetting('playing.start',start)
+    if ADDON.getSetting('vpnmgr.connect') == "true":
+        vpndefault = False
+        if ADDON.getSetting('vpnmgr.default') == "true":
+            vpndefault = True
+        api = VPNAPI()
+        if url[0:9] == 'plugin://':
+            api.filterAndSwitch(url, 0, vpndefault, True)
+        else:
+            if vpndefault: api.defaultVPN(True)
     xbmc.executebuiltin('PlayMedia(%s)' % url)

--- a/playwith.py
+++ b/playwith.py
@@ -6,6 +6,8 @@ import time
 import subprocess
 from subprocess import Popen
 import re
+from vpnapi import VPNAPI
+
 
 def log(what):
     xbmc.log(repr(what))
@@ -106,6 +108,16 @@ if row:
     url = row[0]
 if not url:
     quit()
-
-xbmc.executebuiltin('PlayWith(%s)' % core)
+else:
+    if ADDON.getSetting('vpnmgr.connect') == "true":
+        vpndefault = False
+        if ADDON.getSetting('vpnmgr.default') == "true":
+            vpndefault = True
+        api = VPNAPI()
+        if url[0:9] == 'plugin://':
+            api.filterAndSwitch(url, 0, vpndefault, True)
+        else:
+            if vpndefault: api.defaultVPN(True)    
+    
+xbmc.executebuiltin('PlayWith(%s)' % core
 xbmc.executebuiltin('PlayMedia(%s)' % url)

--- a/resources/playwith/playwith.py
+++ b/resources/playwith/playwith.py
@@ -3,6 +3,7 @@ import xbmc,xbmcaddon,xbmcvfs
 import sqlite3
 from subprocess import Popen
 import datetime,time
+# from vpnapi import VPNAPI
 
 channel = sys.argv[1]
 start = sys.argv[2]
@@ -53,6 +54,17 @@ if row:
     url = row[0]
 if not url:
     quit()
+# Uncomment this if you want to use VPN Mgr filtering.  Need to import VPNAPI.py
+# else:
+#    if ADDON.getSetting('vpnmgr.connect') == "true":
+#        vpndefault = False
+#        if ADDON.getSetting('vpnmgr.default') == "true":
+#            vpndefault = True
+#        api = VPNAPI()
+#        if url[0:9] == 'plugin://':
+#            api.filterAndSwitch(url, 0, vpndefault, True)
+#        else:
+#            if vpndefault: api.defaultVPN(True)
 
 # Find the actual url used to play the stream
 #core = "dummy"

--- a/resources/playwith/playwithchannel.py
+++ b/resources/playwith/playwithchannel.py
@@ -3,6 +3,8 @@ import xbmc,xbmcaddon,xbmcvfs
 import sqlite3
 from subprocess import Popen
 import datetime,time
+# from vpnapi import VPNAPI
+
 channel = sys.argv[1]
 start = sys.argv[2]
 
@@ -51,7 +53,18 @@ if row:
     url = row[0]
 if not url:
     quit()
-
+# Uncomment this if you want to use VPN Mgr filtering.  Need to import VPNAPI.py
+# else:
+#    if ADDON.getSetting('vpnmgr.connect') == "true":
+#        vpndefault = False
+#        if ADDON.getSetting('vpnmgr.default') == "true":
+#            vpndefault = True
+#        api = VPNAPI()
+#        if url[0:9] == 'plugin://':
+#            api.filterAndSwitch(url, 0, vpndefault, True)
+#        else:
+#            if vpndefault: api.defaultVPN(True)     
+    
 # Find the actual url used to play the stream
 #core = "dummy"
 #xbmc.executebuiltin('PlayWith(%s)' % core)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -181,12 +181,19 @@
         <setting label="Minutes after" type="enum" id="autoplaywiths.after" values="0|1|2|3|4|5|10" default="1" visible="eq(-6,true)"/>
         <setting label="Clear Autoplaywiths..." type="action" action="RunScript($CWD/autoplaywith.py)" />
     </category>
-
     <category label="30140">
         <setting type="lsep" label="30137"/>
         <setting type="lsep" label="30138"/>
         <setting label="Reset EPG Data" type="action" action="RunScript($CWD/ResetDatabase.py, 1)" />
         <setting label="Reset Everything" type="action" action="RunScript($CWD/ResetDatabase.py, 2)" />
+    </category>
+    <category label="VPN">
+        <setting type="lsep" label="VPN Manager Connection Switching"/>
+        <setting type="text" label="Install VPN Manager to switch VPN with channels" enable="false" visible="!System.HasAddon(service.vpn.manager)"/>
+        <setting type="text" label="  https://github.com/Zomboided/service.vpn.manager" enable="false" visible="!System.HasAddon(service.vpn.manager)"/>
+        <setting type="text" label="VPN switching can delay changing channels" enable="false" visible="System.HasAddon(service.vpn.manager)"/>
+        <setting id="vpnmgr.connect" label="Use VPN Mgr filtering for channel add-ons" type="bool" visible="System.HasAddon(service.vpn.manager)" default="true" />
+        <setting id="vpnmgr.default" label="Always revert to previous VPN state" type="bool" visible="System.HasAddon(service.vpn.manager)" default="true" />
     </category>
     <category label="Lab1">
         <setting id="find.program.images" label="Find Program Images from OMDb/TVDb/IMDb" type="bool" default="false" />

--- a/vpnapi.py
+++ b/vpnapi.py
@@ -1,0 +1,275 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+#    Copyright (C) 2016 Zomboided
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#    All the code to access the API for the filtering and switching 
+#    functionality of VPN Manager.  Can be imported from the service.vpn.manager 
+#    add-on or can be copied as a complete file and included in a third party 
+#    add-on directly
+
+
+import xbmc
+import xbmcaddon
+import xbmcgui
+import time
+
+class VPNAPI:
+
+    def __init__(self):
+        # Class initialisation.  Fails with a RuntimeError exception if VPN Manager add-on is not available, or too old
+        self.filtered_addons = []
+        self.filtered_windows = []
+        self.primary_vpns = []
+        self.last_updated = 0
+        self.refreshLists()
+        self.default = self.getConnected()
+        xbmc.log("VPN Mgr API : Default is " + self.default, level=xbmc.LOGDEBUG)
+        self.timeout = 30
+        if not xbmc.getCondVisibility("System.HasAddon(service.vpn.manager)"):
+            xbmc.log("VPN Mgr API : VPN Manager is not installed, cannot use filtering", level=xbmc.LOGERROR)
+            raise RuntimeError("VPN Manager is not installed")
+        else:
+            v = int((xbmcaddon.Addon("service.vpn.manager").getAddonInfo("version").strip()).replace(".",""))
+            if v < 310:
+                raise RuntimeError("VPN Manager " + str(v) + " installed, but needs to be v3.1.0 or later")
+
+                
+    def isVPNSetUp(self):
+        # Indicates if the VPN has been set up.  Can be called directly, but is used by
+        # all calls that mess with the connection to ensure the VPN is running.
+        addon = xbmcaddon.Addon("service.vpn.manager")
+        if not addon.getSetting("1_vpn_validated") == "": return True
+        return False
+        
+    
+    def connectToValidated(self, connection, wait):
+        # Given the number of a validated connection, connect to it.  Return True when the connection has happened 
+        # or False if there's a problem connecting (or there's not a VPN connection available for this connection 
+        # number).  Return True without messing with the connection if the current VPN is the same as the VPN being
+        # requested.  The wait parameter will determine if the function returns once the connection has been made, 
+        # or if it's fire and forget (in which case True will be returned regardless)
+        if not self.isVPNSetUp(): return False
+        if connection < 1 or connection > 10: return False
+        connection = connection - 1
+        self.refreshLists()
+        if self.primary_vpns[connection] == "": return False
+        if self.getConnected() == self.primary_vpns[connection]: return True
+        xbmc.log(msg="VPN Mgr API : Connecting to " + self.primary_vpns[connection], level=xbmc.LOGDEBUG)
+        self.setAPICommand(self.primary_vpns[connection])
+        if wait: return self.waitForConnection(self.primary_vpns[connection])
+        return True
+                
+
+    def connectTo(self, connection_name, wait):
+        # Given the ovpn filename of a connection, connect to it.  Return True when the connection has happened 
+        # or False if there's a problem connecting (or there's not a VPN connection available for this connection 
+        # number).  Return True without messing with the connection if the current VPN is the same as the VPN being
+        # requested.  The wait parameter will determine if the function returns once the connection has been made, 
+        # or if it's fire and forget (in which case True will be returned regardless)
+        if not self.isVPNSetUp(): return False
+        if connection_name == "": return False
+        if self.getConnected() == connection_name: return True
+        xbmc.log(msg="VPN Mgr API : Connecting to " + connection_name, level=xbmc.LOGDEBUG)
+        self.setAPICommand(connection_name)
+        if wait: return self.waitForConnection(connection_name)
+        return True
+
+                
+    def disconnect(self, wait):
+        # Disconnect any active VPN connection.  Return True when the connection has disconnected.  If there's
+        # not an active connection, return True anyway.  The wait parameter will determine if the function returns 
+        # once the connection has been made, or if it's fire and forget (in which case True will be returned regardless)
+        if not self.isVPNSetUp(): return False
+        if self.getConnected() == "": return True
+        xbmc.log(msg="VPN Mgr API : Disconnecting", level=xbmc.LOGDEBUG)
+        self.setAPICommand("Disconnect")
+        if wait: return self.waitForConnection("")
+        return True
+
+        
+    def defaultVPN(self, wait):
+        # Return to the default VPN state.  This is a wrapper function to disconnect() and connectTo() with
+        # the behaviour and return values matching those functions.
+        if self.default == "":
+            return self.disconnect(wait)
+        else:
+            return self.connectTo(self.default, wait)
+        
+        
+    def filterAndSwitch(self, path, windowid, default, wait):
+        # Given a path to an addon, and/or a window ID, determine if it's associated with a particular VPN and
+        # switch to that VPN.  Return True when the switch has happened or False if there's a problem switching 
+        # (or there's no VPN that's been set up).  If the connected VPN is the VPN that's been identifed as being 
+        # required, or no filter is found, just return True without messing with the connection.  The default 
+        # parameter is a boolean indicating if the default VPN should be connected to if no filter is found.
+        # The wait parameter will determine if the function returns once the connection has been made, or if it's 
+        # fire and forget (in which case True will be returned regardless).  
+        if not self.isVPNSetUp():
+            return False
+        connection = self.isFiltered(path, windowid)
+        # Switch to the default connection if there's no filter
+        if connection == -1 and default : 
+            xbmc.log(msg="VPN Mgr API : Reconnecting to the default", level=xbmc.LOGDEBUG)
+            return self.defaultVPN(wait)
+        if connection == 0:
+            if self.getConnected() == "": return True
+            xbmc.log(msg="VPN Mgr API : Disconnecting due to filter " + path + " or window ID " + str(windowid), level=xbmc.LOGDEBUG)
+            self.setAPICommand("Disconnect")
+            if wait: return self.waitForConnection("")
+        if connection > 0:
+            connection = connection - 1
+            if self.primary_vpns[connection] == "": return False
+            if self.getConnected() == self.primary_vpns[connection]: return True
+            xbmc.log(msg="VPN Mgr API : Connecting to " + self.primary_vpns[connection] + " due to filter " + path + " or window ID " + str(windowid), level=xbmc.LOGDEBUG)
+            self.setAPICommand(self.primary_vpns[connection])
+            if wait: return self.waitForConnection(self.primary_vpns[connection])
+        return True
+      
+            
+    def isFiltered(self, path, windowid):
+        # Given the path to an addon, and/or a window ID, determine if it's associated with a particular VPN.
+        # Return 0 if given addon is excluded (ie no VPN), 1 to 10 if it needs a particular VPN or -1 if not found
+        # If we're already connected to a primary VPN and the add-on appears multiple times then return the 
+        # current connected VPN if it matches, otherwise return the first.  If there are duplicate entries, 
+        # disconnect will always win.
+        # Get the latest filter data and the current connection
+        self.refreshLists()
+        current = self.getCurrent()
+        # Assume we're not gonna find anything
+        found = -1
+        # Try and filter on the path name.
+        # Ignore local sources (that don't start with a ://)
+        if ("://" in path):
+            # Strip out the leading 'plugin://' or 'addons://' string, and anything trailing the plugin name
+            filtered_addon_path = path[path.index("://")+3:]
+            if "/" in filtered_addon_path:
+                filtered_addon_path = filtered_addon_path[:filtered_addon_path.index("/")]
+            # Can't filter if there's nothing to filter...
+            if not filtered_addon_path == "":
+                # Adjust 11 below if changing number of conn_max
+                for i in range (0, 11):
+                    if not self.filtered_addons[i] == None:
+                        for filtered_string in self.filtered_addons[i]: 
+                            if filtered_addon_path == filtered_string:
+                                if found == -1 : found = i
+                                if i > 0 and i == current : found = i
+                # If we get a match return it
+                if not found == -1: return found
+        # Now try filtering on the window ID
+        if windowid > 0:
+            for i in range (0, 11):
+                if not self.filtered_windows[i] == None:
+                    for filtered_string in self.filtered_windows[i]:
+                        if "-" in filtered_string:
+                            low, high = filtered_string.split("-")
+                            if windowid > int(low) and windowid < int(high):
+                                if found == -1 : found = i
+                                if i > 0 and i == current : found = i
+                        else:
+                            if str(windowid) == filtered_string:
+                                if found == -1 : found = i
+                                if i > 0 and i == current : found = i
+        return found
+
+        
+    def setTimeOut(self, seconds):
+        # Set filterAndSwitch timeout in seconds
+        # Default is 30 seconds (recommended)
+        # timeout is measured in half seconds
+        self.timeout = seconds * 2        
+        
+        
+    def setDefault(self, default):
+        # Override the default connection.  Expects to be passed the name of the connection as an 
+        # ovpn file name.  This is probably only needed when the API object is old and crusty and
+        # there's potential that the .ovpn has changed.  Might be better just to create a new
+        # API object in this case though...
+        if not default == "": 
+            self.default = default
+        
+        
+    # Functions below this line shouldn't need to be called directly
+
+        
+        
+    def waitForConnection(self, connection_name):
+        # Wait for the connection to change to the connection requested
+        # Shouldn't need to call this directly
+        for i in range(0, self.timeout):
+            xbmc.sleep(500)
+            if connection_name == self.getConnected():
+                return True
+        # Connection timed out
+        return False
+
+    
+    def getConnected(self):
+        return xbmcgui.Window(10000).getProperty("VPN_Manager_Connected_Profile_Name")
+    
+    
+    def setAPICommand(self, profile):
+        # Set up the API command for the main service to act upon
+        # Shouldn't need to call this directly
+        xbmcgui.Window(10000).setProperty("VPN_Manager_API_Command", profile)
+
+        
+    def getCurrent(self):
+        # Compare the current connected VPN to the list of primary VPNs to see if one of the possible
+        # filtered connections is in use.  Used by isFiltered, shouldn't be called directly
+        found = -1
+        current = xbmcgui.Window(10000).getProperty("VPN_Manager_Connected_Profile_Name")
+        if current == "": return found
+        # Adjust 10 below if changing number of conn_max
+        for i in range (0, 10):                    
+            if not self.primary_vpns[i] == "" and current == self.primary_vpns[i]:
+                found = i+1
+        return found
+    
+        
+    def refreshLists(self):
+        # This function will refresh the list of filters and VPNs being used.  It doesn't need to be called 
+        # directly as it will be called before an add-on/window is checked if the data has changed
+        try:
+            changed = int(xbmcgui.Window(10000).getProperty("VPN_Manager_Lists_Last_Refreshed"))
+        except:
+            # If there's no refreshed time stamp, force a refresh with whatever data is available
+            changed = self.last_updated
+        if self.last_updated > changed:
+            return
+        # Get a handle to the VPN Mgr add-on to read the settings data
+        addon = xbmcaddon.Addon("service.vpn.manager")
+        del self.filtered_addons[:]
+        del self.filtered_windows[:]
+        del self.primary_vpns[:]
+        # Adjust 11 below if changing number of conn_max
+        for i in range (0, 11):
+            # Load up the list of primary VPNs
+            if i>0: self.primary_vpns.append(addon.getSetting(str(i)+"_vpn_validated"))
+            # Load up the addon filter list
+            addon_string = ""
+            if i == 0 : addon_string = addon.getSetting("vpn_excluded_addons")
+            else : addon_string = addon.getSetting(str(i)+"_vpn_addons")
+            if not addon_string == "" : self.filtered_addons.append(addon_string.split(","))
+            else : self.filtered_addons.append(None)   
+            # Load up the window filter list
+            window_string = ""
+            if i == 0 : window_string = addon.getSetting("vpn_excluded_windows")
+            else : window_string = addon.getSetting(str(i)+"_vpn_windows")
+            if not window_string == "" : self.filtered_windows.append(window_string.split(","))
+            else : self.filtered_windows.append(None)
+        # Store the time the filters were last updated
+        self.last_updated = int(time.time())

--- a/vpnapi.py
+++ b/vpnapi.py
@@ -198,8 +198,7 @@ class VPNAPI:
         # ovpn file name.  This is probably only needed when the API object is old and crusty and
         # there's potential that the .ovpn has changed.  Might be better just to create a new
         # API object in this case though...
-        if not default == "": 
-            self.default = default
+        self.default = default
         
         
     # Functions below this line shouldn't need to be called directly


### PR DESCRIPTION
Add VPN Mgr support, allowing VPN connection filtering to be used when using different add-ons within the TV guide.

Works by checking and changing a connection before an add-on is used to provide a stream.

Works entirely independently and will not cause errors if VPN Mgr is not installed.  Requires no user install/setup beyond what's required by both Fullscreen and VPN Mgr already.

I'm not confident that I have covered every situation here (such as autoplay and playwith).  If there are other blobs of code that end up calling a stream from an add-on, I can look at those (I started to look at the PlayMedia calls but couldn't tell if they were being fed add-on streams).

Cheers