### PR TITLE
gui / settings: add help control to show invisible buttons

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -225,6 +225,8 @@ class TVGuide(xbmcgui.WindowXML):
     C_MAIN_MOUSE_AUTOPLAYWITH = 4320
     C_MAIN_MOUSE_AUTOPLAY = 4321
     C_MAIN_MOUSE_REMIND = 4322
+    C_MAIN_MOUSE_HELP_CONTROL = 4323
+    C_MAIN_MOUSE_HELP_BUTTON = 4324
     C_MAIN_BACKGROUND = 4600
     C_MAIN_HEADER = 4601
     C_MAIN_FOOTER = 4602
@@ -475,6 +477,9 @@ class TVGuide(xbmcgui.WindowXML):
         else:
             self.setControlVisible(self.C_MAIN_PIP,False)
             self.setControlVisible(self.C_MAIN_VIDEO,True)
+
+        if ADDON.getSetting('help.invisiblebuttons') == 'false':
+            self.setControlVisible(self.C_MAIN_MOUSE_HELP_BUTTON,False)
 
         self._hideControl(self.C_MAIN_OSD_MOUSE_CONTROLS)
         self._hideControl(self.C_QUICK_EPG_MOUSE_CONTROLS)
@@ -1334,6 +1339,12 @@ class TVGuide(xbmcgui.WindowXML):
         elif controlId == self.C_MAIN_MOUSE_REMIND:
             self.showFullReminders()
             return
+        elif controlId == self.C_MAIN_MOUSE_HELP_BUTTON and ADDON.getSetting('help.invisiblebuttons') == 'true':
+            if xbmc.getCondVisibility('!Control.IsVisible(4323)'):
+                self._hideControl(self.C_MAIN_MOUSE_HELP_CONTROL)
+            else:
+                self._showControl(self.C_MAIN_MOUSE_HELP_CONTROL)
+            return
         elif controlId == self.C_MAIN_VIDEO_BUTTON_LAST_CHANNEL:
             self.osdProgram = self.database.getCurrentProgram(self.lastChannel)
             self._showContextMenu(self.osdProgram)
@@ -1365,7 +1376,7 @@ class TVGuide(xbmcgui.WindowXML):
         elif controlId == self.C_QUICK_EPG_BUTTON_FIRST:
             self.quickViewStartDate = datetime.datetime.today()
             self.quickViewStartDate -= datetime.timedelta(minutes=self.quickViewStartDate.minute % 30, seconds=self.quickViewStartDate.second)
-            self.onRedrawQuickEPG(self.channelIdx, self.quickViewStartDate)
+            self.onRedrawQuickEPG(0, self.quickViewStartDate)
             return
         elif controlId == self.C_QUICK_EPG_BUTTON_CH_UP:
             self.quickFocusPoint.y = self.quickEpgView.bottom

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,7 @@
     <category label="Help">
         <setting label="Command Keys" type="action" action="RunScript($CWD/help.py,commands)" />
         <setting label="AutoPlayWith" type="action" action="RunScript($CWD/help.py,autoplaywith)" />
+        <setting id="help.invisiblebuttons" label="Enable help/question mark for invisible buttons" type="bool" default="false" />
     </category>
     <category label="30101">
         <setting id="xmltv.type" label="XMLTV Source" type="enum" enable="true" visible="true" default="0" values="File|Url" />


### PR DESCRIPTION
hey primaeval.
i've added a new control to show up the invisible buttons.
I placed a question mark in my main epg, which toggles the view of the buttons on click, and also a option in settings to show up the question mark.

What do you think?


