### PR TITLE
invisible buttons help control: help button toggles the setting now

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -490,8 +490,10 @@ class TVGuide(xbmcgui.WindowXML):
             self.setControlVisible(self.C_MAIN_PIP,False)
             self.setControlVisible(self.C_MAIN_VIDEO,True)
 
-        if ADDON.getSetting('help.invisiblebuttons') == 'false':
-            self.setControlVisible(self.C_MAIN_MOUSE_HELP_BUTTON,False)
+        if ADDON.getSetting('help.invisiblebuttons') == 'true':
+            self.setControlVisible(self.C_MAIN_MOUSE_HELP_CONTROL,True)
+        else:
+            self.setControlVisible(self.C_MAIN_MOUSE_HELP_CONTROL,False)
 
         self._hideControl(self.C_MAIN_OSD_MOUSE_CONTROLS)
         self._hideControl(self.C_QUICK_EPG_MOUSE_CONTROLS)
@@ -1227,6 +1229,13 @@ class TVGuide(xbmcgui.WindowXML):
             ADDON.setSetting('epg.video.pip', 'false')
         self.reopen()
 
+    def invisibleButtonsHelp_toggle(self):
+        if ADDON.getSetting('help.invisiblebuttons') == 'false':
+            ADDON.setSetting('help.invisiblebuttons', 'true')
+        elif ADDON.getSetting('help.invisiblebuttons') == 'true':
+            ADDON.setSetting('help.invisiblebuttons', 'false')
+        self.reopen()
+
     def reopen(self):
         import gui
         xbmc.executebuiltin('XBMC.ActivateWindow(home)')
@@ -1351,11 +1360,8 @@ class TVGuide(xbmcgui.WindowXML):
         elif controlId == self.C_MAIN_MOUSE_REMIND:
             self.showFullReminders()
             return
-        elif controlId == self.C_MAIN_MOUSE_HELP_BUTTON and ADDON.getSetting('help.invisiblebuttons') == 'true':
-            if xbmc.getCondVisibility('!Control.IsVisible(4323)'):
-                self._hideControl(self.C_MAIN_MOUSE_HELP_CONTROL)
-            else:
-                self._showControl(self.C_MAIN_MOUSE_HELP_CONTROL)
+        elif controlId == self.C_MAIN_MOUSE_HELP_BUTTON:
+            self.invisibleButtonsHelp_toggle()
             return
         elif controlId == self.C_MAIN_VIDEO_BUTTON_LAST_CHANNEL:
             self.osdProgram = self.database.getCurrentProgram(self.lastChannel)
@@ -3461,7 +3467,7 @@ class TVGuide(xbmcgui.WindowXML):
             if program.channel in channelsWithoutPrograms:
                 channelsWithoutPrograms.remove(program.channel)
 
-            if isPlaying and (self.currentChannel == channels[idx]):
+            if isPlaying and self.currentChannel and (self.currentChannel == channels[idx]):
                 channel_playing = True
             else:
                 channel_playing = False
@@ -4066,6 +4072,7 @@ class PopupMenu(xbmcgui.WindowXMLDialog):
     C_POPUP_PROGRAM_PREVIOUS_BIG = 44505
     C_POPUP_PROGRAM_NEXT_BIG = 44506
     C_POPUP_PROGRAM_NOW_BIG = 44507
+    C_POPUP_MOUSE_HELP_CONTROL = 44510
 
 
     def __new__(cls, database, program, showRemind, showAutoplay, showAutoplaywith, category, categories):
@@ -4126,6 +4133,11 @@ class PopupMenu(xbmcgui.WindowXMLDialog):
             setupChannelTitleControl = self.getControl(self.C_POPUP_SETUP_CHANNEL_TITLE)
 
         self.mode = MODE_POPUP_MENU
+
+        if ADDON.getSetting('help.invisiblebuttons') == 'true':
+            self.setControlVisible(self.C_POPUP_MOUSE_HELP_CONTROL,True)
+        else:
+            self.setControlVisible(self.C_POPUP_MOUSE_HELP_CONTROL,False)
 
         if self.program.channel:
             channelTitleControl.setLabel(self.program.channel.title)


### PR DESCRIPTION
i could not figure how to pass the info, if the help marker control for the invisible buttons are already shown in the main screen (via help button click), from the main TVguide Class to the PopupMenu Class and further set this as condition to show the the control there too... :/
So i decided to break down the help button function to toggle the setting to show up the help control, similar to the pip toggle.