### PR TITLE
Channel Shortcut by Sort Number

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -634,6 +634,11 @@ class TVGuide(xbmcgui.WindowXML):
                 if self.channel_number == channelList[i].id:
                      self.channelIdx = i
                      break
+        elif ADDON.getSetting('channel.shortcut') == '3':
+             for i in range(len(channelList)):
+                if int(self.channel_number) == channelList[i].weight:
+                     self.channelIdx = i
+                     break
         else:
             self.channelIdx = int(self.channel_number) - 1
         self.channel_number = ""
@@ -3562,6 +3567,8 @@ class TVGuide(xbmcgui.WindowXML):
                     self.setControlLabel(4410 + idx, channel_index_format % (self.channelIdx + idx + 1))
                 elif ADDON.getSetting('channel.shortcut') == '2':
                     self.setControlLabel(4410 + idx, channel.id)
+                elif ADDON.getSetting('channel.shortcut') == '3':
+                    self.setControlLabel(4410 + idx, channel_index_format % channel.weight)
                 else:
                     self.setControlLabel(4410 + idx, ' ')
                 if (channel.logo is not None and showLogo == True):
@@ -3597,7 +3604,7 @@ class TVGuide(xbmcgui.WindowXML):
             if control:
                 control.setWidth(176)
                 control.setHeight(self.epgView.cellHeight-2)
-                control.setPosition(2,top)
+                control.setPosition(5,top)
 
         name = remove_formatting(ADDON.getSetting('epg.nofocus.color'))
         color = colors.color_name[name]

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -85,7 +85,7 @@
         <setting id="catchup.channel" label="Show Catchup Channel" type="bool" default="false" />
 		<setting id="catchup.hours" label="Catchup Channel Hours" type="number" default="8" />
         <setting type="lsep" label="Channel Shortcuts (xmltv Ids must be Numeric)"/>
-        <setting id="channel.shortcut" label="Channel Shortcut Type" type="enum" default="None" values="None|Index|xmltv Id" />
+        <setting id="channel.shortcut" label="Channel Shortcut Type" type="enum" default="None" values="None|Index|xmltv Id|Sort Number" />
         <setting id="channel.shortcut.direct" label="Start When Any Number Key Pressed (or map Shift Key to start)" visible="!eq(-1,0)" type="bool" default="false" />
         <setting id="channel.shortcut.behaviour" label="Auto-Play Channel On Numeric Input" visible="!eq(-2,0)" type="enum" default="1" values="Always Scroll|Scroll in EPG, Play in TV Mode|Always Play" />
         <setting id="channel.index.digits" label="Channel Shortcut Digits" visible="!eq(-3,0)" default="3" type="number"/>


### PR DESCRIPTION
Allows the channel shortcut to use the sort number instead of the index. This way when the user changes the category, the channel number stays the same.